### PR TITLE
feat: add device whitelist enforcement

### DIFF
--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/controller/DeviceRegistrationController.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/controller/DeviceRegistrationController.java
@@ -1,0 +1,82 @@
+package cat.ajterrassa.validaciofactures.controller;
+
+import cat.ajterrassa.validaciofactures.model.DeviceRegistration;
+import cat.ajterrassa.validaciofactures.model.DeviceRegistrationStatus;
+import cat.ajterrassa.validaciofactures.repository.DeviceRegistrationRepository;
+import cat.ajterrassa.validaciofactures.repository.UsuariRepository;
+import cat.ajterrassa.validaciofactures.model.Usuari;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class DeviceRegistrationController {
+
+    @Autowired
+    private DeviceRegistrationRepository deviceRepository;
+
+    @Autowired
+    private UsuariRepository usuariRepository;
+
+    @PostMapping("/devices/register")
+    public ResponseEntity<?> registerDevice(@RequestBody FidRequest request, Principal principal) {
+        Long userId = null;
+        if (principal != null) {
+            Usuari user = usuariRepository.findByEmail(principal.getName()).orElse(null);
+            if (user != null) {
+                userId = user.getId();
+            }
+        }
+        DeviceRegistration registration = deviceRepository.findByFid(request.getFid())
+                .orElse(DeviceRegistration.builder()
+                        .fid(request.getFid())
+                        .status(DeviceRegistrationStatus.PENDING)
+                        .build());
+        registration.setUserId(userId);
+        deviceRepository.save(registration);
+        return ResponseEntity.ok(registration.getStatus());
+    }
+
+    @GetMapping("/admin/devices")
+    public List<DeviceRegistration> listDevices() {
+        return deviceRepository.findAll();
+    }
+
+    @PostMapping("/admin/devices/{fid}/approve")
+    public ResponseEntity<?> approveDevice(@PathVariable String fid) {
+        DeviceRegistration registration = deviceRepository.findByFid(fid).orElse(null);
+        if (registration == null) {
+            return ResponseEntity.notFound().build();
+        }
+        registration.setStatus(DeviceRegistrationStatus.APPROVED);
+        deviceRepository.save(registration);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/admin/devices/{fid}/revoke")
+    public ResponseEntity<?> revokeDevice(@PathVariable String fid) {
+        DeviceRegistration registration = deviceRepository.findByFid(fid).orElse(null);
+        if (registration == null) {
+            return ResponseEntity.notFound().build();
+        }
+        registration.setStatus(DeviceRegistrationStatus.REVOKED);
+        deviceRepository.save(registration);
+        return ResponseEntity.ok().build();
+    }
+
+    public static class FidRequest {
+        private String fid;
+
+        public String getFid() {
+            return fid;
+        }
+
+        public void setFid(String fid) {
+            this.fid = fid;
+        }
+    }
+}

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/filter/DeviceAuthorizationFilter.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/filter/DeviceAuthorizationFilter.java
@@ -1,0 +1,54 @@
+package cat.ajterrassa.validaciofactures.filter;
+
+import cat.ajterrassa.validaciofactures.model.DeviceRegistration;
+import cat.ajterrassa.validaciofactures.model.DeviceRegistrationStatus;
+import cat.ajterrassa.validaciofactures.repository.DeviceRegistrationRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+
+@Component
+public class DeviceAuthorizationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private DeviceRegistrationRepository deviceRepository;
+
+    private static final String FID_HEADER = "X-Firebase-Installation-Id";
+
+    private static final Set<String> EXCLUDED_PATHS = Set.of(
+            "/api/auth",
+            "/api/devices/register",
+            "/config",
+            "/ping"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String fid = request.getHeader(FID_HEADER);
+        if (fid == null) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return;
+        }
+        DeviceRegistration registration = deviceRepository.findByFid(fid).orElse(null);
+        if (registration == null || registration.getStatus() != DeviceRegistrationStatus.APPROVED) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return EXCLUDED_PATHS.stream().anyMatch(path::startsWith);
+    }
+}

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/model/DeviceRegistration.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/model/DeviceRegistration.java
@@ -1,0 +1,57 @@
+package cat.ajterrassa.validaciofactures.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeviceRegistration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String fid;
+
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private DeviceRegistrationStatus status;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFid() {
+        return fid;
+    }
+
+    public void setFid(String fid) {
+        this.fid = fid;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public DeviceRegistrationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(DeviceRegistrationStatus status) {
+        this.status = status;
+    }
+}

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/model/DeviceRegistrationStatus.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/model/DeviceRegistrationStatus.java
@@ -1,0 +1,7 @@
+package cat.ajterrassa.validaciofactures.model;
+
+public enum DeviceRegistrationStatus {
+    PENDING,
+    APPROVED,
+    REVOKED
+}

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/repository/DeviceRegistrationRepository.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/repository/DeviceRegistrationRepository.java
@@ -1,0 +1,11 @@
+package cat.ajterrassa.validaciofactures.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import cat.ajterrassa.validaciofactures.model.DeviceRegistration;
+
+public interface DeviceRegistrationRepository extends JpaRepository<DeviceRegistration, Long> {
+    Optional<DeviceRegistration> findByFid(String fid);
+}


### PR DESCRIPTION
## Summary
- add device registration entity and repository
- expose endpoints to register, approve and revoke devices
- enforce device approval via request filter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d5acd8883288f26d2c154fbf646