### PR TITLE
feat: integrate Play Integrity token retrieval

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -86,6 +86,8 @@ dependencies {
 
     implementation(platform("com.google.firebase:firebase-bom:33.3.0"))
     implementation("com.google.firebase:firebase-installations-ktx")
+    implementation("com.google.android.play:integrity:1.3.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")
 
     // --- Debug / Tests (els que ja tens) ---
     debugImplementation("androidx.compose.ui:ui-tooling-preview:1.5.4")

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/MainActivity.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/MainActivity.kt
@@ -16,10 +16,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Decideix la pantalla d'inici segons token
-        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
-        val hasToken = !prefs.getString("token", null).isNullOrEmpty()
-        val startDestination = if (hasToken) Rutes.Inici else Rutes.Login
+        val startDestination = Rutes.Splash
 
         setContent {
             val navController = rememberNavController() // <-- es NavHostController

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/ApiClient.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/ApiClient.kt
@@ -34,6 +34,9 @@ object ApiClient {
         FidProvider.fid?.let { fid ->
             builder.addHeader("X-Firebase-Installation-Id", fid)
         }
+        IntegrityTokenProvider.token?.let { token ->
+            builder.addHeader("X-Integrity-Token", token)
+        }
         chain.proceed(builder.build())
     }
 

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/IntegrityService.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/IntegrityService.kt
@@ -1,0 +1,29 @@
+package com.ajterrassa.validaciofacturesalbarans.data.network
+
+import android.content.Context
+import android.util.Base64
+import com.google.android.play.integrity.IntegrityManagerFactory
+import com.google.android.play.integrity.IntegrityTokenRequest
+import kotlinx.coroutines.tasks.await
+import java.util.UUID
+
+class IntegrityService(private val context: Context) {
+    suspend fun requestToken(): String? {
+        return try {
+            val integrityManager = IntegrityManagerFactory.create(context)
+            val nonce = Base64.encodeToString(UUID.randomUUID().toString().toByteArray(), Base64.NO_WRAP)
+            val request = IntegrityTokenRequest.builder()
+                .setNonce(nonce)
+                .build()
+            val response = integrityManager.requestIntegrityToken(request).await()
+            response.token()
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+object IntegrityTokenProvider {
+    @Volatile
+    var token: String? = null
+}

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/navigation/AppNavGraph.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/navigation/AppNavGraph.kt
@@ -17,6 +17,10 @@ fun AppNavGraph(
 ) {
     NavHost(navController = navController, startDestination = startDestination) {
 
+        composable(Rutes.Splash) {
+            SplashScreen(navController = navController)
+        }
+
         composable(Rutes.Login) {
             LoginScreen(navController = navController)
         }

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/navigation/Rutes.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/navigation/Rutes.kt
@@ -5,6 +5,7 @@ object Rutes {
 
     }
 
+    const val Splash = "splash"
     const val Login = "login"
     const val Inici = "home"
     const val NouAlbara = "nou-albara"

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/ui/screens/SplashScreen.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/ui/screens/SplashScreen.kt
@@ -1,0 +1,29 @@
+package com.ajterrassa.validaciofacturesalbarans.ui.screens
+
+import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import com.ajterrassa.validaciofacturesalbarans.data.network.IntegrityService
+import com.ajterrassa.validaciofacturesalbarans.data.network.IntegrityTokenProvider
+import com.ajterrassa.validaciofacturesalbarans.navigation.Rutes
+
+@Composable
+fun SplashScreen(navController: NavController) {
+    val context = navController.context
+    LaunchedEffect(Unit) {
+        val service = IntegrityService(context)
+        val token = service.requestToken()
+        IntegrityTokenProvider.token = token
+        val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val hasToken = !prefs.getString("token", null).isNullOrEmpty()
+        val destination = if (hasToken) Rutes.Inici else Rutes.Login
+        navController.navigate(destination) {
+            popUpTo(0) { inclusive = true }
+        }
+    }
+    Box(modifier = Modifier.fillMaxSize())
+}


### PR DESCRIPTION
## Summary
- integrate Play Integrity API and store integrity token
- collect token at new Splash screen before navigation
- send integrity token with login and device registration requests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b053048afc8328999a4c80787effa8