### PR TITLE
Add ConfigService and enforce immediate app updates

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -87,6 +87,9 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.3.0"))
     implementation("com.google.firebase:firebase-installations-ktx")
 
+    implementation("com.google.android.play:app-update:2.1.0")
+    implementation("com.google.android.play:app-update-ktx:2.1.0")
+
     // --- Debug / Tests (els que ja tens) ---
     debugImplementation("androidx.compose.ui:ui-tooling-preview:1.5.4")
     debugImplementation("androidx.compose.ui:ui-tooling:1.5.4")

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/MainActivity.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/MainActivity.kt
@@ -6,15 +6,46 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.lifecycleScope
+import com.ajterrassa.validaciofacturesalbarans.BuildConfig
+import com.ajterrassa.validaciofacturesalbarans.data.network.ApiClient
 import com.ajterrassa.validaciofacturesalbarans.data.repo.AlbaraPendingRepository
 import com.ajterrassa.validaciofacturesalbarans.navigation.AppNavGraph
 import com.ajterrassa.validaciofacturesalbarans.navigation.Rutes
 import com.ajterrassa.validaciofacturesalbarans.ui.components.RootScaffold
 import com.ajterrassa.validaciofacturesalbarans.ui.theme.ValidacioFacturesAlbaransTheme
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.UpdateAvailability
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        lifecycleScope.launch {
+            try {
+                val config = ApiClient.configService.getAppConfig()
+                val minVersionCode = config.minSupportedVersion.filter { it.isDigit() }.toIntOrNull()
+                if (minVersionCode != null && BuildConfig.VERSION_CODE < minVersionCode) {
+                    val appUpdateManager = AppUpdateManagerFactory.create(this@MainActivity)
+                    appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+                        if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                            info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+                        ) {
+                            appUpdateManager.startUpdateFlow(
+                                info,
+                                this@MainActivity,
+                                AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build()
+                            )
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+                // Ignore errors
+            }
+        }
 
         // Decideix la pantalla d'inici segons token
         val prefs = getSharedPreferences("auth", MODE_PRIVATE)

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/model/AppConfig.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/model/AppConfig.kt
@@ -1,0 +1,7 @@
+package com.ajterrassa.validaciofacturesalbarans.data.model
+
+data class AppConfig(
+    val minSupportedVersion: String,
+    val message: String,
+    val updateUrl: String
+)

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/ApiClient.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/ApiClient.kt
@@ -49,13 +49,14 @@ object ApiClient {
         //.protocols(listOf(Protocol.HTTP_1_1))
         .build()
 
-    // Retrofit + ApiService
-    val apiService: ApiService by lazy {
+    private val retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .client(client)
             .build()
-            .create(ApiService::class.java)
     }
+
+    val apiService: ApiService by lazy { retrofit.create(ApiService::class.java) }
+    val configService: ConfigService by lazy { retrofit.create(ConfigService::class.java) }
 }

--- a/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/ConfigService.kt
+++ b/app/app/src/main/java/com/ajterrassa/validaciofacturesalbarans/data/network/ConfigService.kt
@@ -1,0 +1,9 @@
+package com.ajterrassa.validaciofacturesalbarans.data.network
+
+import com.ajterrassa.validaciofacturesalbarans.data.model.AppConfig
+import retrofit2.http.GET
+
+interface ConfigService {
+    @GET("/config/app")
+    suspend fun getAppConfig(): AppConfig
+}


### PR DESCRIPTION
## Summary
- fetch `/config/app` via new ConfigService
- trigger immediate in-app update when version is below minSupportedVersion

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b0535caafc8328a365c763518d4a93