### PR TITLE
feat(frontend): add device admin page

### DIFF
--- a/frontend/src/api/devices.ts
+++ b/frontend/src/api/devices.ts
@@ -1,0 +1,40 @@
+// src/api/devices.ts
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from './client';
+
+export type DeviceStatus = 'PENDING' | 'APPROVED' | 'REVOKED';
+
+export interface Device {
+  id: number;
+  fid: string;
+  userId: number | null;
+  status: DeviceStatus;
+}
+
+export const getDevices = (): Promise<Device[]> =>
+  api.get('/admin/devices').then((r) => r.data);
+
+export const approveDevice = (fid: string): Promise<void> =>
+  api.post(`/admin/devices/${fid}/approve`).then((r) => r.data);
+
+export const revokeDevice = (fid: string): Promise<void> =>
+  api.post(`/admin/devices/${fid}/revoke`).then((r) => r.data);
+
+export const useDevices = () =>
+  useQuery({ queryKey: ['devices'], queryFn: getDevices });
+
+export const useApproveDevice = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: approveDevice,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['devices'] }),
+  });
+};
+
+export const useRevokeDevice = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: revokeDevice,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['devices'] }),
+  });
+};

--- a/frontend/src/pages/DeviceAdminPage.tsx
+++ b/frontend/src/pages/DeviceAdminPage.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Button, Container, Loader, Table, Text, Title } from '@mantine/core';
+import { useDevices, useApproveDevice, useRevokeDevice } from '../api/devices';
+
+export default function DeviceAdminPage() {
+  const { data: devices, isLoading, error } = useDevices();
+  const approve = useApproveDevice();
+  const revoke = useRevokeDevice();
+
+  if (isLoading)
+    return (
+      <Container py="xl" style={{ textAlign: 'center' }}>
+        <Loader />
+      </Container>
+    );
+  if (error)
+    return (
+      <Container py="xl">
+        <Text color="red">Error: {(error as Error).message}</Text>
+      </Container>
+    );
+  if (!devices?.length)
+    return (
+      <Container py="xl">
+        <Text>No hi ha dispositius.</Text>
+      </Container>
+    );
+
+  return (
+    <Container py="xl" style={{ fontFamily: 'Poppins, sans-serif' }}>
+      <Title order={2}>DISPOSITIUS</Title>
+      <Table striped highlightOnHover>
+        <thead>
+          <tr>
+            <th>FID</th>
+            <th>Estat</th>
+            <th>Accions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {devices.map((d) => (
+            <tr key={d.fid}>
+              <td>{d.fid}</td>
+              <td>{d.status}</td>
+              <td>
+                <Button size="xs" mr="xs" onClick={() => approve.mutate(d.fid)}>
+                  Aprova
+                </Button>
+                <Button
+                  size="xs"
+                  color="red"
+                  variant="outline"
+                  onClick={() => revoke.mutate(d.fid)}
+                >
+                  Revoca
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Container>
+  );
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -40,6 +40,9 @@ const ProveidorsList = lazy(() => import("./pages/ProveidorsList"));
 const ProveidorFormNew = lazy(() => import("./pages/ProveidorFormNew"));
 const ProveidorFormEdit = lazy(() => import("./pages/ProveidorFormEdit"));
 
+//DEVICES
+const DeviceAdminPage = lazy(() => import("./pages/DeviceAdminPage"));
+
 const routesConfig: RouteObject[] = [
   {
     path: "/login",
@@ -220,6 +223,16 @@ const routesConfig: RouteObject[] = [
         element: (
           <RutaProtegidaPerRol rolsPermesos={["ADMINISTRADOR", "GESTOR"]}>
             <EdificisList />
+          </RutaProtegidaPerRol>
+        ),
+      },
+
+      // DEVICES (només admin)
+      {
+        path: "devices",
+        element: (
+          <RutaProtegidaPerRol rolsPermesos={["ADMINISTRADOR"]}>
+            <DeviceAdminPage />
           </RutaProtegidaPerRol>
         ),
       },


### PR DESCRIPTION
## Summary
- add device API hooks for device approvals
- implement DeviceAdminPage with approve and revoke actions
- register protected `/devices` route for administrators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0563b2dac8328805a4e832b789f08