### PR TITLE
Protect device admin endpoints with administrator role

### DIFF
--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/controller/DeviceRegistrationController.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/controller/DeviceRegistrationController.java
@@ -8,6 +8,7 @@ import cat.ajterrassa.validaciofactures.repository.UsuariRepository;
 import cat.ajterrassa.validaciofactures.model.Usuari;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -50,12 +51,14 @@ public class DeviceRegistrationController {
         return deviceRepository.countByAppVersion();
     }
 
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
     @GetMapping("/admin/devices")
     public List<DeviceRegistration> listDevices() {
         return deviceRepository.findAll();
     }
 
     @PostMapping("/admin/devices/{fid}/approve")
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
     public ResponseEntity<?> approveDevice(@PathVariable String fid) {
         DeviceRegistration registration = deviceRepository.findByFid(fid).orElse(null);
         if (registration == null) {
@@ -67,6 +70,7 @@ public class DeviceRegistrationController {
     }
 
     @PostMapping("/admin/devices/{fid}/revoke")
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
     public ResponseEntity<?> revokeDevice(@PathVariable String fid) {
         DeviceRegistration registration = deviceRepository.findByFid(fid).orElse(null);
         if (registration == null) {

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/security/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/security/UserDetailsServiceImpl.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.*;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
+import java.util.List;
 
 @Service
 public class UserDetailsServiceImpl implements UserDetailsService {
@@ -20,14 +20,17 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         Usuari usuari = usuariRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("Usuari no trobat amb email: " + email));
 
-        // ✅ Prefixa el rol amb "ROLE_" per compatibilitat amb Spring Security
-        String roleName = "ROLE_" + usuari.getRol().name();
-        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(roleName);
-
         if (usuari.getRol() == null) {
             throw new UsernameNotFoundException("L'usuari no té cap rol assignat");
         }
 
-        return new User(usuari.getEmail(), usuari.getContrasenya(), Collections.singletonList(authority));
+        // ✅ Prefixa el rol amb "ROLE_" per compatibilitat amb Spring Security i
+        //    exposa també l'autoritat sense prefix per poder utilitzar hasAuthority
+        String roleName = "ROLE_" + usuari.getRol().name();
+        List<SimpleGrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority(roleName),
+                new SimpleGrantedAuthority(usuari.getRol().name()));
+
+        return new User(usuari.getEmail(), usuari.getContrasenya(), authorities);
     }
 }

--- a/backend/src/test/java/cat/ajterrassa/validaciofactures/controller/DeviceRegistrationControllerSecurityTest.java
+++ b/backend/src/test/java/cat/ajterrassa/validaciofactures/controller/DeviceRegistrationControllerSecurityTest.java
@@ -1,0 +1,129 @@
+package cat.ajterrassa.validaciofactures.controller;
+
+import cat.ajterrassa.validaciofactures.model.DeviceRegistration;
+import cat.ajterrassa.validaciofactures.model.DeviceRegistrationStatus;
+import cat.ajterrassa.validaciofactures.repository.DeviceRegistrationRepository;
+import cat.ajterrassa.validaciofactures.repository.UsuariRepository;
+import cat.ajterrassa.validaciofactures.security.JwtFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DeviceRegistrationControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DeviceRegistrationRepository deviceRegistrationRepository;
+
+    @MockBean
+    private UsuariRepository usuariRepository;
+
+    @MockBean
+    private JwtFilter jwtFilter;
+
+    @BeforeEach
+    void setUpJwtFilter() throws Exception {
+        Mockito.doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(request, response);
+            return null;
+        }).when(jwtFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRADOR"})
+    void listDevicesAccessibleForAdministrators() throws Exception {
+        when(deviceRegistrationRepository.findAll()).thenReturn(List.of(DeviceRegistration.builder()
+                .fid("fid-1")
+                .status(DeviceRegistrationStatus.PENDING)
+                .build()));
+
+        mockMvc.perform(get("/api/admin/devices"))
+                .andExpect(status().isOk());
+
+        verify(deviceRegistrationRepository).findAll();
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"GESTOR"})
+    void listDevicesForbiddenForNonAdministrators() throws Exception {
+        mockMvc.perform(get("/api/admin/devices"))
+                .andExpect(status().isForbidden());
+
+        verify(deviceRegistrationRepository, never()).findAll();
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRADOR"})
+    void approveDeviceAllowedForAdministrators() throws Exception {
+        DeviceRegistration registration = DeviceRegistration.builder()
+                .fid("fid-approve")
+                .status(DeviceRegistrationStatus.PENDING)
+                .build();
+        when(deviceRegistrationRepository.findByFid("fid-approve")).thenReturn(Optional.of(registration));
+
+        mockMvc.perform(post("/api/admin/devices/{fid}/approve", "fid-approve"))
+                .andExpect(status().isOk());
+
+        verify(deviceRegistrationRepository).save(registration);
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"GESTOR"})
+    void approveDeviceForbiddenForNonAdministrators() throws Exception {
+        mockMvc.perform(post("/api/admin/devices/{fid}/approve", "fid-approve"))
+                .andExpect(status().isForbidden());
+
+        verify(deviceRegistrationRepository, never()).findByFid("fid-approve");
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMINISTRADOR"})
+    void revokeDeviceAllowedForAdministrators() throws Exception {
+        DeviceRegistration registration = DeviceRegistration.builder()
+                .fid("fid-revoke")
+                .status(DeviceRegistrationStatus.PENDING)
+                .build();
+        when(deviceRegistrationRepository.findByFid("fid-revoke")).thenReturn(Optional.of(registration));
+
+        mockMvc.perform(post("/api/admin/devices/{fid}/revoke", "fid-revoke"))
+                .andExpect(status().isOk());
+
+        verify(deviceRegistrationRepository).save(registration);
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"GESTOR"})
+    void revokeDeviceForbiddenForNonAdministrators() throws Exception {
+        mockMvc.perform(post("/api/admin/devices/{fid}/revoke", "fid-revoke"))
+                .andExpect(status().isForbidden());
+
+        verify(deviceRegistrationRepository, never()).findByFid("fid-revoke");
+    }
+}


### PR DESCRIPTION
## Summary
- enforce administrator-only access on device management endpoints with method security
- expose both ROLE_ and raw authorities when loading users to support hasAuthority checks
- add MockMvc tests validating administrators succeed and other roles receive 403 responses

## Testing
- ./backend/mvnw test *(fails: unable to download Maven wrapper distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66657d580832892a7ad0dbe830b14