### PR TITLE
Add Play Integrity validation filter and tests

### DIFF
--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/config/SecurityConfig.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/config/SecurityConfig.java
@@ -19,6 +19,9 @@ import org.springframework.security.config.Customizer;
 import cat.ajterrassa.validaciofactures.security.CustomAccessDeniedHandler;
 import cat.ajterrassa.validaciofactures.security.JwtFilter;
 import cat.ajterrassa.validaciofactures.security.UserDetailsServiceImpl;
+import cat.ajterrassa.validaciofactures.filter.DeviceAuthorizationFilter;
+import cat.ajterrassa.validaciofactures.filter.PlayIntegrityFilter;
+import cat.ajterrassa.validaciofactures.filter.VersionCheckFilter;
 
 @Configuration
 @EnableMethodSecurity // ✅ AIXÒ ÉS EL QUE NECESSITES per habilitar les anotacions @PreAuthorize i @PostAuthorize
@@ -32,6 +35,15 @@ public class SecurityConfig {
 
     @Autowired
     private CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Autowired
+    private PlayIntegrityFilter playIntegrityFilter;
+
+    @Autowired
+    private DeviceAuthorizationFilter deviceAuthorizationFilter;
+
+    @Autowired
+    private VersionCheckFilter versionCheckFilter;
 
     /**
      * Criterio de organización: 1. Primero se definen las rutas públicas (sin
@@ -93,6 +105,9 @@ public class SecurityConfig {
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // Filtros y autenticación
                 .authenticationProvider(authenticationProvider())
+                .addFilterBefore(playIntegrityFilter, JwtFilter.class)
+                .addFilterBefore(deviceAuthorizationFilter, JwtFilter.class)
+                .addFilterAfter(versionCheckFilter, DeviceAuthorizationFilter.class)
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/filter/PlayIntegrityFilter.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/filter/PlayIntegrityFilter.java
@@ -1,0 +1,55 @@
+package cat.ajterrassa.validaciofactures.filter;
+
+import cat.ajterrassa.validaciofactures.service.PlayIntegrityService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+
+@Component
+public class PlayIntegrityFilter extends OncePerRequestFilter {
+
+    static final String INTEGRITY_HEADER = "X-Play-Integrity-Token";
+    private static final Logger logger = LoggerFactory.getLogger(PlayIntegrityFilter.class);
+    private static final Set<String> EXCLUDED_PATHS = Set.of(
+            "/api/auth",
+            "/api/devices/register",
+            "/config",
+            "/ping"
+    );
+
+    private final PlayIntegrityService playIntegrityService;
+
+    public PlayIntegrityFilter(PlayIntegrityService playIntegrityService) {
+        this.playIntegrityService = playIntegrityService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String integrityToken = request.getHeader(INTEGRITY_HEADER);
+        if (!playIntegrityService.validateToken(integrityToken)) {
+            logger.warn("Rejected request to {} due to invalid Play Integrity token", request.getRequestURI());
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.getWriter().write("{\"error\":\"INVALID_PLAY_INTEGRITY_TOKEN\"}");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return EXCLUDED_PATHS.stream().anyMatch(path::startsWith);
+    }
+}

--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/service/PlayIntegrityService.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/service/PlayIntegrityService.java
@@ -1,0 +1,67 @@
+package cat.ajterrassa.validaciofactures.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class PlayIntegrityService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PlayIntegrityService.class);
+
+    private final boolean validationEnabled;
+    private final Set<String> acceptedTokens;
+
+    public PlayIntegrityService(
+            @Value("${play.integrity.validation-enabled:true}") boolean validationEnabled,
+            @Value("${play.integrity.accepted-tokens:}") String acceptedTokens
+    ) {
+        this(validationEnabled, parseTokens(acceptedTokens));
+    }
+
+    public PlayIntegrityService(boolean validationEnabled, Collection<String> acceptedTokens) {
+        this.validationEnabled = validationEnabled;
+        this.acceptedTokens = acceptedTokens == null ? Collections.emptySet() : acceptedTokens.stream()
+                .map(String::trim)
+                .filter(token -> !token.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    public boolean validateToken(String token) {
+        if (!validationEnabled) {
+            logger.debug("Play Integrity validation is disabled. Allowing request by configuration.");
+            return true;
+        }
+        if (token == null || token.isBlank()) {
+            logger.warn("Rejected request without Play Integrity token");
+            return false;
+        }
+        if (acceptedTokens.isEmpty()) {
+            logger.warn("No accepted Play Integrity tokens configured; rejecting request");
+            return false;
+        }
+        boolean valid = acceptedTokens.contains(token);
+        if (!valid) {
+            logger.warn("Rejected request with unknown Play Integrity token (hash: {})",
+                    Integer.toHexString(token.hashCode()));
+        }
+        return valid;
+    }
+
+    private static Collection<String> parseTokens(String acceptedTokens) {
+        if (acceptedTokens == null || acceptedTokens.isBlank()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(acceptedTokens.split(","))
+                .map(String::trim)
+                .filter(token -> !token.isEmpty())
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/test/java/cat/ajterrassa/validaciofactures/filter/PlayIntegrityFilterTest.java
+++ b/backend/src/test/java/cat/ajterrassa/validaciofactures/filter/PlayIntegrityFilterTest.java
@@ -1,0 +1,77 @@
+package cat.ajterrassa.validaciofactures.filter;
+
+import cat.ajterrassa.validaciofactures.service.PlayIntegrityService;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlayIntegrityFilterTest {
+
+    private static final String PROTECTED_PATH = "/api/albarans/save-with-file";
+
+    @Test
+    void allowsRequestWhenTokenIsValid() throws ServletException, IOException {
+        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(PROTECTED_PATH);
+        request.addHeader(PlayIntegrityFilter.INTEGRITY_HEADER, "valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> invoked.set(true));
+
+        assertThat(invoked.get()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void rejectsRequestWhenTokenIsMissing() throws ServletException, IOException {
+        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(PROTECTED_PATH);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> invoked.set(true));
+
+        assertThat(invoked.get()).isFalse();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    void rejectsRequestWhenTokenIsInvalid() throws ServletException, IOException {
+        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(PROTECTED_PATH);
+        request.addHeader(PlayIntegrityFilter.INTEGRITY_HEADER, "invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> invoked.set(true));
+
+        assertThat(invoked.get()).isFalse();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    void skipsValidationForExcludedPaths() throws ServletException, IOException {
+        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/auth/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> invoked.set(true));
+
+        assertThat(invoked.get()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayIntegrityService that encapsulates the Play Integrity token validation contract
- register the new PlayIntegrityFilter in the Spring Security chain together with the existing device and version filters
- cover success and failure scenarios with unit tests for the filter

## Testing
- mvn test *(fails: unable to download dependencies from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d675fe65e483288c1c6fe375cb19bc