### PR TITLE
Skip Play Integrity validation for web clients

### DIFF
--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/filter/ClientPlatformResolver.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/filter/ClientPlatformResolver.java
@@ -1,0 +1,110 @@
+package cat.ajterrassa.validaciofactures.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Helper that determines from which platform (web browser or mobile app) an HTTP request originates.
+ *
+ * <p>The detection prioritises the explicit {@code X-Client-Platform} header so that the Android
+ * application can always mark itself as mobile. When the header is not present, the resolver falls
+ * back to the {@code Origin} header (browser requests executed through CORS) and, as an additional
+ * safeguard, the {@code User-Agent} value.</p>
+ */
+@Component
+public class ClientPlatformResolver {
+
+    static final String PLATFORM_HEADER = "X-Client-Platform";
+    private static final String WEB_PLATFORM = "web";
+    private static final Logger logger = LoggerFactory.getLogger(ClientPlatformResolver.class);
+
+    private final Set<String> allowedWebOrigins;
+
+    public ClientPlatformResolver(
+            @Value("${platform.web.origins:${cors.allowed.origin:}}") String configuredOrigins
+    ) {
+        this(parseOrigins(configuredOrigins));
+    }
+
+    ClientPlatformResolver(Set<String> allowedWebOrigins) {
+        this.allowedWebOrigins = allowedWebOrigins == null ? Collections.emptySet() : allowedWebOrigins;
+    }
+
+    public boolean isWebRequest(HttpServletRequest request) {
+        String headerPlatform = request.getHeader(PLATFORM_HEADER);
+        if (headerPlatform != null && !headerPlatform.isBlank()) {
+            boolean isWeb = WEB_PLATFORM.equalsIgnoreCase(headerPlatform.trim());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Detected platform via header {} = {} (web = {})", PLATFORM_HEADER, headerPlatform, isWeb);
+            }
+            return isWeb;
+        }
+
+        String origin = request.getHeader("Origin");
+        if (origin != null && !origin.isBlank()) {
+            boolean matchesOrigin = matchesAllowedOrigin(origin);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Detected platform via Origin header {} (web = {})", origin, matchesOrigin);
+            }
+            if (matchesOrigin) {
+                return true;
+            }
+        }
+
+        String userAgent = request.getHeader("User-Agent");
+        boolean looksLikeBrowser = userAgent != null && userAgent.toLowerCase(Locale.ROOT).contains("mozilla");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Detected platform via User-Agent '{}' (web = {})", userAgent, looksLikeBrowser);
+        }
+        return looksLikeBrowser;
+    }
+
+    public boolean isMobileRequest(HttpServletRequest request) {
+        String headerPlatform = request.getHeader(PLATFORM_HEADER);
+        if (headerPlatform != null && !headerPlatform.isBlank()) {
+            return !WEB_PLATFORM.equalsIgnoreCase(headerPlatform.trim());
+        }
+        return !isWebRequest(request);
+    }
+
+    private boolean matchesAllowedOrigin(String origin) {
+        if (allowedWebOrigins.isEmpty()) {
+            return true;
+        }
+        String normalised = normaliseOrigin(origin);
+        return allowedWebOrigins.contains(normalised);
+    }
+
+    private static Set<String> parseOrigins(String configuredOrigins) {
+        if (configuredOrigins == null || configuredOrigins.isBlank()) {
+            return Collections.emptySet();
+        }
+        Set<String> result = new LinkedHashSet<>();
+        Arrays.stream(configuredOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(ClientPlatformResolver::normaliseOrigin)
+                .forEach(result::add);
+        return result;
+    }
+
+    private static String normaliseOrigin(String origin) {
+        if (origin == null) {
+            return "";
+        }
+        String trimmed = origin.trim();
+        if (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed.toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/src/test/java/cat/ajterrassa/validaciofactures/filter/DeviceAuthorizationFilterTest.java
+++ b/backend/src/test/java/cat/ajterrassa/validaciofactures/filter/DeviceAuthorizationFilterTest.java
@@ -1,0 +1,82 @@
+package cat.ajterrassa.validaciofactures.filter;
+
+import cat.ajterrassa.validaciofactures.model.DeviceRegistration;
+import cat.ajterrassa.validaciofactures.model.DeviceRegistrationStatus;
+import cat.ajterrassa.validaciofactures.repository.DeviceRegistrationRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceAuthorizationFilterTest {
+
+    private static final String PROTECTED_ENDPOINT = "/api/factures";
+
+    @Mock
+    private DeviceRegistrationRepository deviceRegistrationRepository;
+
+    private DeviceAuthorizationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        ClientPlatformResolver resolver = new ClientPlatformResolver(Set.of("http://localhost:5173"));
+        filter = new DeviceAuthorizationFilter(deviceRegistrationRepository, resolver);
+    }
+
+    @Test
+    void shouldBypassValidationForWebRequests() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(PROTECTED_ENDPOINT);
+        request.addHeader("Origin", "http://localhost:5173");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) -> {});
+
+        verifyNoInteractions(deviceRegistrationRepository);
+        assertThat(response.getStatus()).isNotEqualTo(HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    @Test
+    void shouldRejectMobileRequestsWithoutFid() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(PROTECTED_ENDPOINT);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) -> {});
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verifyNoInteractions(deviceRegistrationRepository);
+    }
+
+    @Test
+    void shouldAllowMobileRequestsWithApprovedDevice() throws ServletException, IOException {
+        DeviceRegistration registration = DeviceRegistration.builder()
+                .fid("abc")
+                .status(DeviceRegistrationStatus.APPROVED)
+                .build();
+        when(deviceRegistrationRepository.findByFid("abc")).thenReturn(Optional.of(registration));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(PROTECTED_ENDPOINT);
+        request.addHeader("X-Firebase-Installation-Id", "abc");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) -> {});
+
+        verify(deviceRegistrationRepository).findByFid("abc");
+        assertThat(response.getStatus()).isNotEqualTo(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/backend/src/test/java/cat/ajterrassa/validaciofactures/filter/PlayIntegrityFilterTest.java
+++ b/backend/src/test/java/cat/ajterrassa/validaciofactures/filter/PlayIntegrityFilterTest.java
@@ -2,76 +2,83 @@ package cat.ajterrassa.validaciofactures.filter;
 
 import cat.ajterrassa.validaciofactures.service.PlayIntegrityService;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import jakarta.servlet.FilterChain;
+import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class PlayIntegrityFilterTest {
 
-    private static final String PROTECTED_PATH = "/api/albarans/save-with-file";
+    private static final String SECURED_ENDPOINT = "/api/factures";
+
+    @Mock
+    private PlayIntegrityService playIntegrityService;
+
+    private PlayIntegrityFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        ClientPlatformResolver resolver = new ClientPlatformResolver(Set.of("http://localhost:5173"));
+        filter = new PlayIntegrityFilter(playIntegrityService, resolver);
+    }
 
     @Test
-    void allowsRequestWhenTokenIsValid() throws ServletException, IOException {
-        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
+    void shouldSkipValidationForWebRequestsIdentifiedByOrigin() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI(PROTECTED_PATH);
+        request.setRequestURI(SECURED_ENDPOINT);
+        request.addHeader("Origin", "http://localhost:5173");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        verify(playIntegrityService, never()).validateToken(anyString());
+        assertThat(response.getStatus()).isNotEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldRejectMobileRequestsWithoutValidToken() throws ServletException, IOException {
+        when(playIntegrityService.validateToken(null)).thenReturn(false);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(SECURED_ENDPOINT);
+        request.addHeader(ClientPlatformResolver.PLATFORM_HEADER, "android");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        verify(playIntegrityService).validateToken(null);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldAllowMobileRequestsWithValidToken() throws ServletException, IOException {
+        when(playIntegrityService.validateToken("valid-token")).thenReturn(true);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(SECURED_ENDPOINT);
+        request.addHeader(ClientPlatformResolver.PLATFORM_HEADER, "android");
         request.addHeader(PlayIntegrityFilter.INTEGRITY_HEADER, "valid-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
-        AtomicBoolean invoked = new AtomicBoolean(false);
+        FilterChain chain = mock(FilterChain.class);
 
-        filter.doFilter(request, response, (req, res) -> invoked.set(true));
+        filter.doFilter(request, response, chain);
 
-        assertThat(invoked.get()).isTrue();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
-    void rejectsRequestWhenTokenIsMissing() throws ServletException, IOException {
-        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI(PROTECTED_PATH);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        AtomicBoolean invoked = new AtomicBoolean(false);
-
-        filter.doFilter(request, response, (req, res) -> invoked.set(true));
-
-        assertThat(invoked.get()).isFalse();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
-
-    @Test
-    void rejectsRequestWhenTokenIsInvalid() throws ServletException, IOException {
-        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI(PROTECTED_PATH);
-        request.addHeader(PlayIntegrityFilter.INTEGRITY_HEADER, "invalid-token");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        AtomicBoolean invoked = new AtomicBoolean(false);
-
-        filter.doFilter(request, response, (req, res) -> invoked.set(true));
-
-        assertThat(invoked.get()).isFalse();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
-
-    @Test
-    void skipsValidationForExcludedPaths() throws ServletException, IOException {
-        PlayIntegrityFilter filter = new PlayIntegrityFilter(new PlayIntegrityService(true, List.of("valid-token")));
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/api/auth/login");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        AtomicBoolean invoked = new AtomicBoolean(false);
-
-        filter.doFilter(request, response, (req, res) -> invoked.set(true));
-
-        assertThat(invoked.get()).isTrue();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        verify(playIntegrityService).validateToken("valid-token");
+        verify(chain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isNotEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable client platform resolver to detect browser requests using headers or origin
- skip device authorization and Play Integrity checks for web traffic while enforcing them for mobile
- cover web and mobile scenarios with unit tests for both filters

## Testing
- `mvn -q test` *(fails: Maven cannot download Spring Boot parent POM in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b0d9e71883289342c904571b3674