### PR TITLE
Annotate PlayIntegrityService constructor for autowiring

### DIFF
--- a/backend/src/main/java/cat/ajterrassa/validaciofactures/service/PlayIntegrityService.java
+++ b/backend/src/main/java/cat/ajterrassa/validaciofactures/service/PlayIntegrityService.java
@@ -2,6 +2,7 @@ package cat.ajterrassa.validaciofactures.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +20,7 @@ public class PlayIntegrityService {
     private final boolean validationEnabled;
     private final Set<String> acceptedTokens;
 
+    @Autowired
     public PlayIntegrityService(
             @Value("${play.integrity.validation-enabled:true}") boolean validationEnabled,
             @Value("${play.integrity.accepted-tokens:}") String acceptedTokens


### PR DESCRIPTION
## Summary
- mark the PlayIntegrityService configuration constructor with `@Autowired` to ensure proper injection when both constructors exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6cb5d45cc8328b0d704b0b28d1dc6